### PR TITLE
Add proxy support

### DIFF
--- a/lib/bitgo_client/client.rb
+++ b/lib/bitgo_client/client.rb
@@ -31,7 +31,6 @@ module BitgoClient
       body = payload.to_json if payload
 
       log logger, "Request url: #{url}, method: #{method}, body:"
-      log logger, payload
 
       options = {
         method: method,

--- a/lib/bitgo_client/client.rb
+++ b/lib/bitgo_client/client.rb
@@ -27,22 +27,26 @@ module BitgoClient
       @access_token = access_token
     end
 
-    def request(url, payload = nil, method: :get, logger: nil)
+    def request(url, payload = nil, method: :get, logger: nil, proxy: nil)
       body = payload.to_json if payload
 
       log logger, "Request url: #{url}, method: #{method}, body:"
       log logger, payload
 
-      request = Typhoeus::Request.new(
-        url,
+      options = {
         method: method,
         headers: {
           "Authorization" => "Bearer #{access_token}",
           "Content-Type"  => "application/json"
         },
         body: body
-      )
+      }
 
+      unless String(proxy).empty?
+        options[:proxy] = proxy
+      end
+
+      request = Typhoeus::Request.new(url, options)
       request.run
 
       response = request.response

--- a/lib/bitgo_client/v2.rb
+++ b/lib/bitgo_client/v2.rb
@@ -25,20 +25,83 @@ module BitgoClient
       BitgoClient::Client.new(access_token)
     end
 
-    def create_address(wallet_id, coin_code: :tbtc, logger: nil)
-      client.request("#{base_path}/#{coin_code}/wallet/#{wallet_id}/address", method: :post, logger: logger)
+    def create_address(wallet_id, coin_code: :tbtc, logger: nil, proxy: nil)
+      client.request(
+        "#{base_path}/#{coin_code}/wallet/#{wallet_id}/address", 
+        method: :post, 
+        logger: logger,
+        proxy: proxy,
+      )
     end
 
-    def address(wallet_id, address, coin_code: :tbtc, logger: nil)
-      client.request("#{base_path}/#{coin_code}/wallet/#{wallet_id}/address/#{address}", logger: logger)
+    def address(wallet_id, address, coin_code: :tbtc, logger: nil, proxy: nil)
+      client.request(
+        "#{base_path}/#{coin_code}/wallet/#{wallet_id}/address/#{address}", 
+        logger: logger,
+        proxy: proxy,
+      )
     end
 
-    def fee(coin_code: :tbtc, logger: nil)
-      client.request("#{base_path}/#{coin_code}/tx/fee", logger: logger)
+    def fee(coin_code: :tbtc, logger: nil, proxy: nil)
+      client.request(
+        "#{base_path}/#{coin_code}/tx/fee", 
+        logger: logger, 
+        proxy: proxy,
+      )
     end
 
-    def get_transfer(wallet_id, transfer_id, coin_code: :tbtc, logger: nil)
-      client.request("#{base_path}/#{coin_code}/wallet/#{wallet_id}/transfer/#{transfer_id}", logger: logger)
+    def get_transfer(wallet_id, transfer_id, coin_code: :tbtc, logger: nil, proxy: nil)
+      client.request(
+        "#{base_path}/#{coin_code}/wallet/#{wallet_id}/transfer/#{transfer_id}", 
+        logger: logger, 
+        proxy: proxy,
+      )
+    end
+
+    def transactions(wallet_id, coin_code: :tbtc, logger: nil, limit: 25, prev_id: nil, all_tokens: nil, proxy: nil)
+      query_string = build_query_string(
+        limit:     limit,
+        prevId:    prev_id,
+        allTokens: all_tokens
+      )
+
+      client.request(
+        "#{base_path}/#{coin_code}/wallet/#{wallet_id}/tx?#{query_string}", 
+        logger: logger,
+        proxy: proxy,
+      )
+    end
+
+    def transaction(wallet_id, transaction_id, coin_code: :tbtc, logger: nil, proxy: nil)
+      client.request(
+        "#{base_path}/#{coin_code}/wallet/#{wallet_id}/tx/#{transaction_id}", 
+        logger: logger, 
+        proxy: proxy,
+      )
+    end
+
+    def transfers(wallet_id, coin_code: :tbtc, logger: nil, limit: 25, prev_id: nil, all_tokens: nil, proxy: nil)
+      query_string = build_query_string(
+        limit:     limit,
+        prevId:    prev_id,
+        allTokens: all_tokens
+      )
+
+      client.request(
+        "#{base_path}/#{coin_code}/wallet/#{wallet_id}/transfer?#{query_string}", 
+        logger: logger, 
+        proxy: proxy,
+      )
+    end
+
+    def wallet(wallet_id, coin_code: :tbtc, logger: nil, all_tokens: nil, proxy: nil)
+      query_string = build_query_string(allTokens: all_tokens)
+
+      client.request(
+        "#{base_path}/#{coin_code}/wallet/#{wallet_id}?#{query_string}", 
+        logger: logger, 
+        proxy: proxy,
+      )
     end
 
     def send_transaction(wallet_id, payload, coin_code: :tbtc, logger: nil)
@@ -48,36 +111,6 @@ module BitgoClient
         method: :post,
         logger: logger
       )
-    end
-
-    def transactions(wallet_id, coin_code: :tbtc, logger: nil, limit: 25, prev_id: nil, all_tokens: nil)
-      query_string = build_query_string(
-        limit:     limit,
-        prevId:    prev_id,
-        allTokens: all_tokens
-      )
-
-      client.request("#{base_path}/#{coin_code}/wallet/#{wallet_id}/tx?#{query_string}", logger: logger)
-    end
-
-    def transaction(wallet_id, transaction_id, coin_code: :tbtc, logger: nil)
-      client.request("#{base_path}/#{coin_code}/wallet/#{wallet_id}/tx/#{transaction_id}", logger: logger)
-    end
-
-    def transfers(wallet_id, coin_code: :tbtc, logger: nil, limit: 25, prev_id: nil, all_tokens: nil)
-      query_string = build_query_string(
-        limit:     limit,
-        prevId:    prev_id,
-        allTokens: all_tokens
-      )
-
-      client.request("#{base_path}/#{coin_code}/wallet/#{wallet_id}/transfer?#{query_string}", logger: logger)
-    end
-
-    def wallet(wallet_id, coin_code: :tbtc, logger: nil, all_tokens: nil)
-      query_string = build_query_string(allTokens: all_tokens)
-
-      client.request("#{base_path}/#{coin_code}/wallet/#{wallet_id}?#{query_string}", logger: logger)
     end
 
     private

--- a/lib/bitgo_client/v2.rb
+++ b/lib/bitgo_client/v2.rb
@@ -27,8 +27,8 @@ module BitgoClient
 
     def create_address(wallet_id, coin_code: :tbtc, logger: nil, proxy: nil)
       client.request(
-        "#{base_path}/#{coin_code}/wallet/#{wallet_id}/address", 
-        method: :post, 
+        "#{base_path}/#{coin_code}/wallet/#{wallet_id}/address",
+        method: :post,
         logger: logger,
         proxy: proxy,
       )
@@ -36,7 +36,7 @@ module BitgoClient
 
     def address(wallet_id, address, coin_code: :tbtc, logger: nil, proxy: nil)
       client.request(
-        "#{base_path}/#{coin_code}/wallet/#{wallet_id}/address/#{address}", 
+        "#{base_path}/#{coin_code}/wallet/#{wallet_id}/address/#{address}",
         logger: logger,
         proxy: proxy,
       )
@@ -44,16 +44,16 @@ module BitgoClient
 
     def fee(coin_code: :tbtc, logger: nil, proxy: nil)
       client.request(
-        "#{base_path}/#{coin_code}/tx/fee", 
-        logger: logger, 
+        "#{base_path}/#{coin_code}/tx/fee",
+        logger: logger,
         proxy: proxy,
       )
     end
 
     def get_transfer(wallet_id, transfer_id, coin_code: :tbtc, logger: nil, proxy: nil)
       client.request(
-        "#{base_path}/#{coin_code}/wallet/#{wallet_id}/transfer/#{transfer_id}", 
-        logger: logger, 
+        "#{base_path}/#{coin_code}/wallet/#{wallet_id}/transfer/#{transfer_id}",
+        logger: logger,
         proxy: proxy,
       )
     end
@@ -66,7 +66,7 @@ module BitgoClient
       )
 
       client.request(
-        "#{base_path}/#{coin_code}/wallet/#{wallet_id}/tx?#{query_string}", 
+        "#{base_path}/#{coin_code}/wallet/#{wallet_id}/tx?#{query_string}",
         logger: logger,
         proxy: proxy,
       )
@@ -74,8 +74,8 @@ module BitgoClient
 
     def transaction(wallet_id, transaction_id, coin_code: :tbtc, logger: nil, proxy: nil)
       client.request(
-        "#{base_path}/#{coin_code}/wallet/#{wallet_id}/tx/#{transaction_id}", 
-        logger: logger, 
+        "#{base_path}/#{coin_code}/wallet/#{wallet_id}/tx/#{transaction_id}",
+        logger: logger,
         proxy: proxy,
       )
     end
@@ -88,8 +88,8 @@ module BitgoClient
       )
 
       client.request(
-        "#{base_path}/#{coin_code}/wallet/#{wallet_id}/transfer?#{query_string}", 
-        logger: logger, 
+        "#{base_path}/#{coin_code}/wallet/#{wallet_id}/transfer?#{query_string}",
+        logger: logger,
         proxy: proxy,
       )
     end
@@ -98,8 +98,8 @@ module BitgoClient
       query_string = build_query_string(allTokens: all_tokens)
 
       client.request(
-        "#{base_path}/#{coin_code}/wallet/#{wallet_id}?#{query_string}", 
-        logger: logger, 
+        "#{base_path}/#{coin_code}/wallet/#{wallet_id}?#{query_string}",
+        logger: logger,
         proxy: proxy,
       )
     end

--- a/spec/bitgo_client/client_spec.rb
+++ b/spec/bitgo_client/client_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe BitgoClient::Client do
   subject(:client) { described_class.new(WebmockHelper::TOKEN) }
 
   let(:base_path) { WebmockHelper::BASE_PATH }
-
   let(:headers) do
     {
       "Authorization" => "Bearer #{WebmockHelper::TOKEN}",

--- a/spec/bitgo_client/v2_spec.rb
+++ b/spec/bitgo_client/v2_spec.rb
@@ -56,7 +56,7 @@ RSpec.describe BitgoClient::V2 do
       it "calls client request with the correct path" do
         api.wallet(wallet_id)
 
-        expect(client).to have_received(:request).with("#{api.base_path}/tbtc/wallet/#{wallet_id}?", logger: nil)
+        expect(client).to have_received(:request).with("#{api.base_path}/tbtc/wallet/#{wallet_id}?", logger: nil, proxy: nil)
       end
     end
 
@@ -64,7 +64,7 @@ RSpec.describe BitgoClient::V2 do
       it "calls client request with the correct path" do
         api.wallet(wallet_id, coin_code: :xxx)
 
-        expect(client).to have_received(:request).with("#{api.base_path}/xxx/wallet/#{wallet_id}?", logger: nil)
+        expect(client).to have_received(:request).with("#{api.base_path}/xxx/wallet/#{wallet_id}?", logger: nil, proxy: nil)
       end
     end
   end
@@ -75,7 +75,7 @@ RSpec.describe BitgoClient::V2 do
         api.create_address(wallet_id)
 
         expect(client).to have_received(:request)
-          .with("#{api.base_path}/tbtc/wallet/#{wallet_id}/address", method: :post, logger: nil)
+          .with("#{api.base_path}/tbtc/wallet/#{wallet_id}/address", method: :post, logger: nil, proxy: nil)
       end
     end
 
@@ -84,7 +84,7 @@ RSpec.describe BitgoClient::V2 do
         api.create_address(wallet_id, coin_code: :xxx)
 
         expect(client).to have_received(:request)
-          .with("#{api.base_path}/xxx/wallet/#{wallet_id}/address", method: :post, logger: nil)
+          .with("#{api.base_path}/xxx/wallet/#{wallet_id}/address", method: :post, logger: nil, proxy: nil)
       end
     end
   end
@@ -97,7 +97,7 @@ RSpec.describe BitgoClient::V2 do
         api.address(wallet_id, address)
 
         expect(client).to have_received(:request)
-          .with("#{api.base_path}/tbtc/wallet/#{wallet_id}/address/#{address}", logger: nil)
+          .with("#{api.base_path}/tbtc/wallet/#{wallet_id}/address/#{address}", logger: nil, proxy: nil)
       end
     end
 
@@ -106,7 +106,7 @@ RSpec.describe BitgoClient::V2 do
         api.address(wallet_id, address, coin_code: :xxx)
 
         expect(client).to have_received(:request)
-          .with("#{api.base_path}/xxx/wallet/#{wallet_id}/address/#{address}", logger: nil)
+          .with("#{api.base_path}/xxx/wallet/#{wallet_id}/address/#{address}", logger: nil, proxy: nil)
       end
     end
   end
@@ -139,7 +139,7 @@ RSpec.describe BitgoClient::V2 do
         api.transactions(wallet_id)
 
         expect(client).to have_received(:request)
-          .with("#{api.base_path}/tbtc/wallet/#{wallet_id}/tx?limit=25", logger: nil)
+          .with("#{api.base_path}/tbtc/wallet/#{wallet_id}/tx?limit=25", logger: nil, proxy: nil)
       end
     end
 
@@ -148,7 +148,7 @@ RSpec.describe BitgoClient::V2 do
         api.transactions(wallet_id, coin_code: :xxx, limit: 250, prev_id: "xxx42", all_tokens: true)
 
         expect(client).to have_received(:request)
-          .with("#{api.base_path}/xxx/wallet/#{wallet_id}/tx?allTokens=true&limit=250&prevId=xxx42", logger: nil)
+          .with("#{api.base_path}/xxx/wallet/#{wallet_id}/tx?allTokens=true&limit=250&prevId=xxx42", logger: nil, proxy: nil)
       end
     end
   end
@@ -161,7 +161,7 @@ RSpec.describe BitgoClient::V2 do
         api.transaction(wallet_id, tx_id)
 
         expect(client).to have_received(:request)
-          .with("#{api.base_path}/tbtc/wallet/#{wallet_id}/tx/#{tx_id}", logger: nil)
+          .with("#{api.base_path}/tbtc/wallet/#{wallet_id}/tx/#{tx_id}", logger: nil, proxy: nil)
       end
     end
 
@@ -170,7 +170,7 @@ RSpec.describe BitgoClient::V2 do
         api.transaction(wallet_id, tx_id, coin_code: :xxx)
 
         expect(client).to have_received(:request)
-          .with("#{api.base_path}/xxx/wallet/#{wallet_id}/tx/#{tx_id}", logger: nil)
+          .with("#{api.base_path}/xxx/wallet/#{wallet_id}/tx/#{tx_id}", logger: nil, proxy: nil)
       end
     end
   end
@@ -181,7 +181,7 @@ RSpec.describe BitgoClient::V2 do
         api.fee
 
         expect(client).to have_received(:request)
-          .with("#{api.base_path}/tbtc/tx/fee", logger: nil)
+          .with("#{api.base_path}/tbtc/tx/fee", logger: nil, proxy: nil)
       end
     end
 
@@ -190,7 +190,7 @@ RSpec.describe BitgoClient::V2 do
         api.fee(coin_code: :xxx)
 
         expect(client).to have_received(:request)
-          .with("#{api.base_path}/xxx/tx/fee", logger: nil)
+          .with("#{api.base_path}/xxx/tx/fee", logger: nil, proxy: nil)
       end
     end
   end
@@ -201,7 +201,7 @@ RSpec.describe BitgoClient::V2 do
         api.transfers(wallet_id)
 
         expect(client).to have_received(:request)
-          .with("#{api.base_path}/tbtc/wallet/#{wallet_id}/transfer?limit=25", logger: nil)
+          .with("#{api.base_path}/tbtc/wallet/#{wallet_id}/transfer?limit=25", logger: nil, proxy: nil)
       end
     end
 
@@ -210,7 +210,7 @@ RSpec.describe BitgoClient::V2 do
         api.transfers(wallet_id, coin_code: :xxx, limit: 250, prev_id: "xxx42", all_tokens: true)
 
         expect(client).to have_received(:request)
-          .with("#{api.base_path}/xxx/wallet/#{wallet_id}/transfer?allTokens=true&limit=250&prevId=xxx42", logger: nil)
+          .with("#{api.base_path}/xxx/wallet/#{wallet_id}/transfer?allTokens=true&limit=250&prevId=xxx42", logger: nil, proxy: nil)
       end
     end
   end
@@ -223,7 +223,7 @@ RSpec.describe BitgoClient::V2 do
         api.get_transfer(wallet_id, tx_id)
 
         expect(client).to have_received(:request)
-          .with("#{api.base_path}/tbtc/wallet/#{wallet_id}/transfer/#{tx_id}", logger: nil)
+          .with("#{api.base_path}/tbtc/wallet/#{wallet_id}/transfer/#{tx_id}", logger: nil, proxy: nil)
       end
     end
 
@@ -232,7 +232,7 @@ RSpec.describe BitgoClient::V2 do
         api.get_transfer(wallet_id, tx_id, coin_code: :xxx)
 
         expect(client).to have_received(:request)
-          .with("#{api.base_path}/xxx/wallet/#{wallet_id}/transfer/#{tx_id}", logger: nil)
+          .with("#{api.base_path}/xxx/wallet/#{wallet_id}/transfer/#{tx_id}", logger: nil, proxy: nil)
       end
     end
   end


### PR DESCRIPTION
### Problem
Bitgo requires you to choose a list of IP addresses to whitelist. In our case, we have servers in which they use dynamic IP addresses that is expected to change often. 

### Solution
We need to pass our requests to a proxy server so Bitgo can recognize its validity. To do this, we modified this library so it accepts  a`proxy` parameter.

### Usage
```
BitgoClient::V2.new(<access token>, proxy:  <your proxy server>, ... some other options)
```