### PR TITLE
Improve bitgo client performance

### DIFF
--- a/lib/bitgo_client/client.rb
+++ b/lib/bitgo_client/client.rb
@@ -33,6 +33,8 @@ module BitgoClient
       log logger, "Request url: #{url}, method: #{method}, body:"
       log logger, payload
 
+      Typhoeus::Config.memoize = false
+
       request = Typhoeus::Request.new(
         url,
         method: method,

--- a/lib/bitgo_client/client.rb
+++ b/lib/bitgo_client/client.rb
@@ -28,12 +28,13 @@ module BitgoClient
     end
 
     def request(url, payload = nil, method: :get, logger: nil)
+      Typhoeus::Config.memoize = false
+      Typhoeus::Config.cache   = nil
+
       body = payload.to_json if payload
 
       log logger, "Request url: #{url}, method: #{method}, body:"
       log logger, payload
-
-      Typhoeus::Config.memoize = false
 
       request = Typhoeus::Request.new(
         url,


### PR DESCRIPTION
Analisando a gem Typhoeus, identifiquei que o memoize vem habilitado por padrão. Isso faz com que respostas de requisições idênticas (mesmo método/URL/parâmetros/opções) sejam mantidas em memória globalmente. Em cenários com muitas URLs únicas ou alto throughput, esse cache tende a crescer sem limite, o que pode explicar o aumento contínuo de RSS.